### PR TITLE
docs: fix p-retry explanation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ This can be useful when you want to do something specific when a network error h
 
 Unfortunately, Fetch network errors are [not standardized](https://github.com/whatwg/fetch/issues/526) and differ among implementations. This package handles the differences.
 
-For instance, [`p-retry`](https://github.com/sindresorhus/p-retry) uses this package to avoid retrying on network errors.
+For instance, [`p-retry`](https://github.com/sindresorhus/p-retry) uses this package to retry on network errors.
 
 ## Install
 


### PR DESCRIPTION
If I'm reading this correctly:
https://github.com/sindresorhus/p-retry/blob/4f5ec690b52bb4e7c0732d76a97e6bfd1f4e6d03/index.js#L69

The code is exiting early if the error is not a networking issue. A test also covers it:
https://github.com/sindresorhus/p-retry/blob/main/test.js#L51 