### PR TITLE
Added 'network error' to list of messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const objectToString = Object.prototype.toString;
 const isError = value => objectToString.call(value) === '[object Error]';
 
 const errorMessages = new Set([
+	'network error', //chrome
 	'Failed to fetch', // Chrome
 	'NetworkError when attempting to fetch resource.', // Firefox
 	'The Internet connection appears to be offline.', // Safari 16

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const objectToString = Object.prototype.toString;
 const isError = value => objectToString.call(value) === '[object Error]';
 
 const errorMessages = new Set([
-	'network error', //chrome
+	'network error', // Chrome
 	'Failed to fetch', // Chrome
 	'NetworkError when attempting to fetch resource.', // Firefox
 	'The Internet connection appears to be offline.', // Safari 16


### PR DESCRIPTION
Recent versions of chrome seem to return `network error` as the message when a request fails, 

I noticed this issue with the p-retry library,


![image](https://github.com/sindresorhus/is-network-error/assets/412280/d7b69ad8-5045-4a3f-9a9a-b9c584534e35)

