### PR TITLE
fix: add undici terminated check

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const errorMessages = new Set([
 	'Load failed', // Safari 17+
 	'Network request failed', // `cross-fetch`
 	'fetch failed', // Undici (Node.js)
+	'terminated', // Undici (Node.js)
 ]);
 
 export default function isNetworkError(error) {


### PR DESCRIPTION
nodejs/undici may throw a `TypeError('terminated')` if the connection is aborted.

See
https://github.com/nodejs/undici/blob/5d0cd38d6e4b4f8bd27a6a613c76841be6575b35/lib/web/fetch/index.js#L2057-L2059